### PR TITLE
fix(gsh-sdk): Reduce friction with logging and query

### DIFF
--- a/game-server-hosting/server/config.go
+++ b/game-server-hosting/server/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 )
 
@@ -44,8 +45,9 @@ type (
 	}
 )
 
-// newConfigFromFile loads configuration from the specified file.
-func newConfigFromFile(configFile string) (*Config, error) {
+// newConfigFromFile loads configuration from the specified file. The returned ServerLogDir field has its
+// value modified to include the absolute path from the current home directory.
+func newConfigFromFile(configFile string, homeDirectory string) (*Config, error) {
 	var cfg *Config
 
 	f, err := os.Open(configFile)
@@ -74,6 +76,9 @@ func newConfigFromFile(configFile string) (*Config, error) {
 	for i := 0; i < v.NumField(); i++ {
 		delete(cfg.Extra, v.Field(i).Tag.Get("json"))
 	}
+
+	// Fix log directory so that it is relative to $HOME.
+	cfg.ServerLogDir = filepath.Join(homeDirectory, cfg.ServerLogDir)
 
 	// Set query type to the recommended protocol if one is not defined.
 	if cfg.QueryType == "" {

--- a/game-server-hosting/server/config_test.go
+++ b/game-server-hosting/server/config_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func Test_NewConfigFromFile_defaults(t *testing.T) {
-	f := filepath.Join(t.TempDir(), "new-config-from-file")
+	dir := t.TempDir()
+	f := filepath.Join(dir, "new-config-from-file")
 	require.NoError(t,
 		os.WriteFile(f, []byte(
 			`{
@@ -27,7 +28,7 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 		),
 	)
 
-	cfg, err := newConfigFromFile(f)
+	cfg, err := newConfigFromFile(f, dir)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
 		AllocatedUUID: "a-uuid",
@@ -38,7 +39,7 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 		QueryPort:     "9010",
 		QueryType:     QueryProtocolSQP,
 		ServerID:      "1234",
-		ServerLogDir:  "1234/logs",
+		ServerLogDir:  filepath.Join(dir, "1234/logs"),
 		Extra: map[string]string{
 			"a": "b",
 		},
@@ -46,7 +47,8 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 }
 
 func Test_NewConfigFromFile_supported_values(t *testing.T) {
-	f := filepath.Join(t.TempDir(), "new-config-from-file")
+	dir := t.TempDir()
+	f := filepath.Join(dir, "new-config-from-file")
 	require.NoError(t,
 		os.WriteFile(f, []byte(
 			`{
@@ -64,7 +66,7 @@ func Test_NewConfigFromFile_supported_values(t *testing.T) {
 		),
 	)
 
-	cfg, err := newConfigFromFile(f)
+	cfg, err := newConfigFromFile(f, dir)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
 		AllocatedUUID: "a-uuid",
@@ -75,7 +77,7 @@ func Test_NewConfigFromFile_supported_values(t *testing.T) {
 		QueryPort:     "9010",
 		QueryType:     QueryProtocolSQP,
 		ServerID:      "1234",
-		ServerLogDir:  "1234/logs",
+		ServerLogDir:  filepath.Join(dir, "1234/logs"),
 		Extra:         map[string]string{},
 	}, cfg)
 }

--- a/game-server-hosting/server/config_watcher.go
+++ b/game-server-hosting/server/config_watcher.go
@@ -38,7 +38,7 @@ func (s *Server) processInternalEvents() {
 				continue
 			}
 
-			c, err := newConfigFromFile(s.cfgFile)
+			c, err := newConfigFromFile(s.cfgFile, s.homeDir)
 			if err != nil {
 				// Multiplay truncates the file when a deallocation occurs,
 				// which results in two writes. The first write will produce an

--- a/game-server-hosting/server/option.go
+++ b/game-server-hosting/server/option.go
@@ -35,3 +35,11 @@ func WithConfigPath(path string) Option {
 		s.cfgFile = path
 	}
 }
+
+// WithHomeDirectory sets the home directory for the server. In most circumstances, the default value is reasonable
+// to use.
+func WithHomeDirectory(dir string) Option {
+	return func(s *Server) {
+		s.homeDir = dir
+	}
+}

--- a/game-server-hosting/server/option_test.go
+++ b/game-server-hosting/server/option_test.go
@@ -34,3 +34,10 @@ func Test_WithConfigPath(t *testing.T) {
 	WithConfigPath("foo")(s)
 	require.Equal(t, "foo", s.cfgFile)
 }
+
+func Test_WithHomeDirectory(t *testing.T) {
+	t.Parallel()
+	s := &Server{}
+	WithHomeDirectory("foo")(s)
+	require.Equal(t, "foo", s.homeDir)
+}


### PR DESCRIPTION
- Fix the logging directory to be relative to home directory
- Set server name and game map so that the query endpoint responds appropriately to GSH by default
- Create the server logging directory on server startup