### PR TITLE
fix: Add retry logic to backfill approval, make server type an enum

### DIFF
--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -67,11 +67,13 @@ type (
 
 const (
 	// TypeAllocation represents a server which is using the 'allocations' model of server usage.
-	TypeAllocation = Type(0)
+	TypeAllocation = Type(iota)
 
 	// TypeReservation represents a server which is using the 'reservations' model of server usage.
-	TypeReservation = Type(1)
+	TypeReservation
+)
 
+const (
 	// DefaultWriteBufferSizeBytes represents the default size of the write buffer for the query handler.
 	DefaultWriteBufferSizeBytes = 1024
 


### PR DESCRIPTION
The backfill approval endpoint can return 429 (Too Many Requests) - retry the request once in this case to attempt immediate approval. If this doesn't work, we do not retry further, except for the fact a new request will be made a second later. Also, move server types to an iota-based enum.