### PR TITLE
chore: Introduce a better-defined linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,42 @@
+run:
+  concurrency: 4
+  deadline: 5m
+
+linters-settings:
+  cyclop:
+    max-complexity: 20
+  gocyclo:
+    min-complexity: 20
+
+linters:
+  enable-all: true
+  disable:
+    - exhaustive
+    - exhaustruct
+    - exhaustivestruct
+    - funlen
+    - gochecknoglobals
+    - gomoddirectives
+    - interfacer
+    - maligned
+    - gomnd
+    - nestif
+    - paralleltest
+    - scopelint
+    - testpackage
+    - tparallel
+    - wrapcheck
+    - wsl
+    - godox
+    - forcetypeassert
+    - nlreturn
+    - tagliatelle
+    - varnamelen
+    - ireturn
+    - varcheck
+    - deadcode
+    - golint
+    - ifshort
+    - structcheck
+    - nosnakecase
+    - lll

--- a/game-server-hosting/server/bind.go
+++ b/game-server-hosting/server/bind.go
@@ -16,6 +16,9 @@ type (
 	}
 )
 
+// errBindingClosed is an error representing that the UDP binding is closed.
+var errBindingClosed = errors.New("binding is closed")
+
 // newUDPBinding creates a new UDP binding on the specified address.
 func newUDPBinding(bindAddress string, readBufferSizeBytes int, writeBufferSizeBytes int, writeDeadlineDuration time.Duration) (*udpBinding, error) {
 	address, err := net.ResolveUDPAddr("udp4", bindAddress)
@@ -46,7 +49,7 @@ func newUDPBinding(bindAddress string, readBufferSizeBytes int, writeBufferSizeB
 // Read reads data from the open connection into the supplied buffer.
 func (b *udpBinding) Read(buf []byte) (int, *net.UDPAddr, error) {
 	if b.IsDone() {
-		return 0, nil, errors.New("binding is closed")
+		return 0, nil, errBindingClosed
 	}
 
 	return b.conn.ReadFromUDP(buf)
@@ -55,7 +58,7 @@ func (b *udpBinding) Read(buf []byte) (int, *net.UDPAddr, error) {
 // Write writes data to the specified UDP address.
 func (b *udpBinding) Write(buf []byte, to *net.UDPAddr) (int, error) {
 	if b.IsDone() {
-		return 0, errors.New("binding is closed")
+		return 0, errBindingClosed
 	}
 
 	if err := b.conn.SetWriteDeadline(time.Now().Add(b.writeDeadlineDuration)); err != nil {

--- a/game-server-hosting/server/config_test.go
+++ b/game-server-hosting/server/config_test.go
@@ -24,7 +24,7 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 				"a": "b"
 			}`,
 		),
-			0600,
+			0o600,
 		),
 	)
 
@@ -62,7 +62,7 @@ func Test_NewConfigFromFile_supported_values(t *testing.T) {
 				"serverLogDir": "1234/logs"
 			}`,
 		),
-			0600,
+			0o600,
 		),
 	)
 

--- a/game-server-hosting/server/error_test.go
+++ b/game-server-hosting/server/error_test.go
@@ -14,9 +14,9 @@ func Test_pushError(t *testing.T) {
 		chanError: make(chan error, 1),
 	}
 
-	a := errors.New("a")
-	b := errors.New("b")
-	c := errors.New("c")
+	a := errors.New("a") //nolint: goerr113
+	b := errors.New("b") //nolint: goerr113
+	c := errors.New("c") //nolint: goerr113
 
 	s.PushError(a)
 	s.PushError(b)

--- a/game-server-hosting/server/proto/query_test.go
+++ b/game-server-hosting/server/proto/query_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 type (
-	testEncoder struct {
-	}
+	testEncoder struct{}
 
 	// testStruct is a model which includes the supported write types: string, int, unsigned int and struct.
 	testStruct struct {

--- a/game-server-hosting/server/query.go
+++ b/game-server-hosting/server/query.go
@@ -29,10 +29,8 @@ const (
 	QueryProtocolRecommended
 )
 
-var (
-	// ErrUnsupportedQueryType is an error that specifies the provided query type is not supported by this library.Ï"
-	ErrUnsupportedQueryType = errors.New("supplied query type is not supported")
-)
+// ErrUnsupportedQueryType is an error that specifies the provided query type is not supported by this library.
+var ErrUnsupportedQueryType = errors.New("supplied query type is not supported")
 
 // switchQueryProtocol switches to a query protocol specified in the configuration.
 // The query binding endpoints are restarted to serve on this endpoint.

--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -84,10 +84,8 @@ const (
 	DefaultReadBufferSizeBytes = 1024
 )
 
-var (
-	// ErrReservationsNotYetSupported represents that a reservation-based server is not yet supported by the SDK.
-	ErrReservationsNotYetSupported = errors.New("reservations are not yet supported")
-)
+// ErrReservationsNotYetSupported represents that a reservation-based server is not yet supported by the SDK.
+var ErrReservationsNotYetSupported = errors.New("reservations are not yet supported")
 
 // New creates a new instance of Server, denoting which type of server to use.
 func New(serverType Type, opts ...Option) (*Server, error) {
@@ -138,7 +136,7 @@ func (s *Server) Start() error {
 	s.setConfig(c)
 
 	// Create the directory the logs will be present in.
-	if err = os.MkdirAll(c.ServerLogDir, 0744); err != nil {
+	if err = os.MkdirAll(c.ServerLogDir, 0o744); err != nil {
 		return fmt.Errorf("error creating log directory: %w", err)
 	}
 
@@ -225,7 +223,7 @@ func (s *Server) OnConfigurationChanged() <-chan Config {
 func (s *Server) PlayerJoined() int32 {
 	s.stateLock.Lock()
 	defer s.stateLock.Unlock()
-	s.state.CurrentPlayers += 1
+	s.state.CurrentPlayers++
 	return s.state.CurrentPlayers
 }
 
@@ -234,7 +232,7 @@ func (s *Server) PlayerLeft() int32 {
 	s.stateLock.Lock()
 	defer s.stateLock.Unlock()
 	if s.state.CurrentPlayers > 0 {
-		s.state.CurrentPlayers -= 1
+		s.state.CurrentPlayers--
 	}
 	return s.state.CurrentPlayers
 }

--- a/game-server-hosting/server/server_test.go
+++ b/game-server-hosting/server/server_test.go
@@ -46,7 +46,7 @@ func Test_StartStopQuery(t *testing.T) {
 		"queryPort": "%s",
 		"serverID": "1234",
 		"serverLogDir": "1234/logs"
-	}`, strings.Split(queryEndpoint, ":")[1])), 0600))
+	}`, strings.Split(queryEndpoint, ":")[1])), 0o600))
 
 	s, err := New(
 		TypeAllocation,
@@ -132,7 +132,7 @@ func Test_OnConfigurationChanged(t *testing.T) {
 func Test_OnError(t *testing.T) {
 	t.Parallel()
 
-	e := errors.New("bang")
+	e := errors.New("bang") //nolint: goerr113
 	s, err := New(TypeAllocation)
 	require.NoError(t, err)
 

--- a/matchmaker/server/backfill.go
+++ b/matchmaker/server/backfill.go
@@ -9,17 +9,17 @@ type (
 	// Documentation: https://services.docs.unity.com/matchmaker/v2/index.html#tag/Backfill/operation/approveBackfillTicket
 	BackfillTicket struct {
 		// ID represents the backfill ticket ID.
-		ID string
+		ID string `json:"id"`
 
 		// Connection represents the IP address and port of the server that creates the backfill.
 		// The IP address format is ip:port.
-		Connection string
+		Connection string `json:"connection"`
 
 		// Attributes represents an object that holds a dictionary of attributes (number or string),
 		// indexed by the attribute name. The attributes are compared against the corresponding filters
 		// defined in the matchmaking config and used to segment the ticket population into pools.
 		// The default pool is used if a pool isn't provided.
-		Attributes map[string]float64
+		Attributes map[string]float64 `json:"attributes"`
 	}
 )
 

--- a/matchmaker/server/backfill_internal.go
+++ b/matchmaker/server/backfill_internal.go
@@ -14,7 +14,7 @@ import (
 )
 
 type (
-	// backfillWrapFunc is an alias for a function which can be wrapped by `wrapWithConfigAndJWT()`
+	// backfillWrapFunc is an alias for a function which can be wrapped by `wrapWithConfigAndJWT()`.
 	backfillWrapFunc func(c *gsh.Config, token string) (*BackfillTicket, error)
 
 	// tokenResponse is the representation of a token and an error from the payload proxy service.

--- a/matchmaker/server/backfill_internal_test.go
+++ b/matchmaker/server/backfill_internal_test.go
@@ -166,7 +166,7 @@ func Test_wrapWithConfigAndJWT(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"localProxyUrl": "%s",
 		"queryPort": "%s"
-	}`, proxy.URL, strings.Split(queryEndpoint, ":")[1])), 0600))
+	}`, proxy.URL, strings.Split(queryEndpoint, ":")[1])), 0o600))
 
 	s, err := New(gsh.TypeAllocation, gsh.WithConfigPath(path))
 	require.NoError(t, err)

--- a/matchmaker/server/server_test.go
+++ b/matchmaker/server/server_test.go
@@ -43,7 +43,7 @@ func Test_StartStopQuery(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"queryPort": "%s",
 		"serverLogDir": "1234/logs"
-	}`, strings.Split(queryEndpoint, ":")[1])), 0600))
+	}`, strings.Split(queryEndpoint, ":")[1])), 0o600))
 
 	s, err := New(
 		gsh.TypeAllocation,


### PR DESCRIPTION
Add `.golangci.yml` which strictly defines which linters we want to use. Fix any issues brought up by linter after applying this change.