### PR TITLE
fix: Address comments from previous PR

### DIFF
--- a/game-server-hosting/server/event_watcher_test.go
+++ b/game-server-hosting/server/event_watcher_test.go
@@ -41,3 +41,18 @@ func Test_listenForEvents(t *testing.T) {
 	require.Equal(t, "alloc-id", <-s.OnDeallocate())
 	close(s.done)
 }
+
+func Test_listenForEvents_badServerID(t *testing.T) {
+	t.Parallel()
+
+	s, err := New(TypeAllocation)
+	require.NoError(t, err)
+
+	s.currentConfig = Config{
+		ServerID: "NaN",
+	}
+
+	go s.listenForEvents()
+	err = <-s.eventWatcherReady
+	require.ErrorContains(t, err, "error parsing server ID")
+}

--- a/game-server-hosting/server/internal/localproxy/client.go
+++ b/game-server-hosting/server/internal/localproxy/client.go
@@ -52,9 +52,9 @@ func (c *Client) Start() error {
 
 // Stop stops the client.
 func (c *Client) Stop() error {
-	c.centrifugeClient.Close()
+	err := c.centrifugeClient.Close()
 	close(c.done)
-	return nil
+	return err
 }
 
 // RegisterCallback registers a callback function for the specified EventType.

--- a/matchmaker/server/backfill_internal_test.go
+++ b/matchmaker/server/backfill_internal_test.go
@@ -148,7 +148,8 @@ func Test_wrapWithConfigAndJWT(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"localProxyUrl": "%s",
 		"queryPort": "%s",
-		"serverLogDir": "%s"
+		"serverLogDir": "%s",
+		"serverID": "1"
 	}`, svr.Host, strings.Split(queryEndpoint, ":")[1], dir)), 0o600))
 
 	s, err := New(gsh.TypeAllocation, gsh.WithConfigPath(path))

--- a/matchmaker/server/server_test.go
+++ b/matchmaker/server/server_test.go
@@ -49,7 +49,8 @@ func Test_StartStopQuery(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"queryPort": "%s",
 		"serverLogDir": "%s",
-		"localProxyUrl": "%s"
+		"localProxyUrl": "%s",
+		"serverID": "1"
 	}`, port, filepath.Join(dir, "logs"), svr.Host)), 0o600))
 
 	s, err := New(


### PR DESCRIPTION
- Defend against non-numeric server ID in `listenForEvents()`
- Return a proper error from `Stop()` in `localproxy.Client`
- Defer wait group closing in the scenario the above method panics