### PR TITLE
feat: Purge stale challenges from SQP query handler

### DIFF
--- a/game-server-hosting/server/proto/sqp/sqp_test.go
+++ b/game-server-hosting/server/proto/sqp/sqp_test.go
@@ -3,6 +3,7 @@ package sqp
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/proto"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,12 @@ func Test_Respond(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, q)
+
+	// Add a scale challenge to make sure the responder cleans it up.
+	const staleKey = "stale-challenge"
+	q.challenges.Store(staleKey, challengeEntry{
+		expiryUTC: time.Now().Add(-1 * time.Hour),
+	})
 
 	addr := "client-addr:65534"
 
@@ -53,4 +60,91 @@ func Test_Respond(t *testing.T) {
 		),
 		resp,
 	)
+
+	// Ensure stale key has been purged
+	require.Eventually(t, func() bool {
+		_, ok := q.challenges.Load(staleKey)
+		return !ok
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func Test_Respond_noChallenge(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	resp, err := q.Respond(
+		"my-addr",
+		bytes.Join(
+			[][]byte{
+				{1},
+				{0, 0, 0, 0}, // challenge
+				{0, 1},       // SQP version
+				{1},          // Request chunks (server info only)
+			},
+			nil,
+		),
+	)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, ErrNoChallenge)
+}
+
+func Test_Respond_mismatchedChallenge(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	addr := "client-addr:65534"
+
+	// Challenge packet
+	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})
+	require.NoError(t, err)
+	require.Equal(t, byte(0), resp[0])
+
+	resp, err = q.Respond(
+		addr,
+		bytes.Join(
+			[][]byte{
+				{1},
+				{0, 0, 0, 0}, // challenge
+				{0, 1},       // SQP version
+				{1},          // Request chunks (server info only)
+			},
+			nil,
+		),
+	)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, ErrChallengeMismatch)
+}
+
+func Test_purgeStaleChallenges(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	q.challenges.Store("127.0.0.1", challengeEntry{expiryUTC: now.Add(-1 * time.Minute)})
+	q.challenges.Store("127.0.0.2", challengeEntry{expiryUTC: now.Add(1 * time.Minute)})
+	q.challenges.Store("127.0.0.3", challengeEntry{expiryUTC: now.Add(-1 * time.Hour)})
+
+	q.purgeStaleChallenges(now)
+
+	keys := make([]string, 0)
+	q.challenges.Range(func(key any, _ any) bool {
+		keys = append(keys, key.(string))
+		return true
+	})
+
+	require.Equal(t, []string{"127.0.0.2"}, keys)
 }

--- a/game-server-hosting/server/query.go
+++ b/game-server-hosting/server/query.go
@@ -80,13 +80,17 @@ func (s *Server) restartQueryEndpoint(c Config) error {
 
 // handleQuery handles responding to query commands on an incoming UDP port.
 func (s *Server) handleQuery() {
-	size := 16
+	buf := make([]byte, 16)
 
 	s.wg.Add(1)
 	defer s.wg.Done()
 
 	for {
-		buf := make([]byte, size)
+		// Clear buffer before use
+		for i := range buf {
+			buf[i] = 0
+		}
+
 		_, to, err := s.queryBind.Read(buf)
 		if err != nil {
 			if s.queryBind.IsDone() {


### PR DESCRIPTION
Fixes an issue where the challenge buffer can be filled by asking for a challenge but never using it. To resolve this, any challenges over 1 minute old are purged asynchronously from the challenger buffer on a subsequent challenge request.