### PR TITLE
feat(a2s): Support S2C_CHALLENGE

### DIFF
--- a/game-server-hosting/server/proto/a2s/a2s.go
+++ b/game-server-hosting/server/proto/a2s/a2s.go
@@ -2,6 +2,7 @@ package a2s
 
 import (
 	"bytes"
+	"encoding/binary"
 	"runtime"
 	"sync/atomic"
 
@@ -11,8 +12,14 @@ import (
 type (
 	// QueryResponder implements proto.QueryResponder for the A2S protocol.
 	QueryResponder struct {
-		enc   *encoder
-		state *proto.QueryState
+		*proto.QueryBase
+		enc *encoder
+	}
+
+	// challengeWireFormat describes the format of a S2C_CHALLENGE query response.
+	challengeWireFormat struct {
+		Header    []byte
+		Challenge uint32
 	}
 
 	// infoWireFormat describes the format of a A2S_INFO query response.
@@ -32,58 +39,139 @@ type (
 		Visibility  byte
 		VACEnabled  byte
 	}
+
+	// infoRequest represents the request format for an A2S_INFO query.
+	infoRequest struct {
+		Payload   string
+		Challenge uint32
+	}
 )
 
 var (
-	a2sInfoRequest  = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x54}
-	a2sInfoResponse = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x49}
+	a2sInfoRequest       = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x54}
+	a2sInfoResponse      = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x49}
+	s2cChallengeResponse = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x41}
 )
 
 // NewQueryResponder returns creates a new responder capable of responding
 // to a2s-formatted queries.
 func NewQueryResponder(state *proto.QueryState) (*QueryResponder, error) {
 	q := &QueryResponder{
-		enc:   &encoder{},
-		state: state,
+		QueryBase: &proto.QueryBase{
+			State: state,
+		},
+		enc: &encoder{},
 	}
 
 	return q, nil
 }
 
 // Respond writes a query response to the requester in the SQP wire protocol.
-func (q *QueryResponder) Respond(_ string, buf []byte) ([]byte, error) {
+func (q *QueryResponder) Respond(clientAddress string, buf []byte) ([]byte, error) {
 	if bytes.Equal(buf[0:5], a2sInfoRequest) {
-		return q.handleInfoRequest()
+		return q.handleInfoRequest(clientAddress, buf)
 	}
 
 	return nil, NewUnsupportedQueryError(buf[0:5])
 }
 
-func (q *QueryResponder) handleInfoRequest() ([]byte, error) {
-	resp := bytes.NewBuffer(nil)
-	f := infoWireFormat{
-		Header:      a2sInfoResponse,
-		Protocol:    1,
-		ServerName:  "n/a",
-		GameMap:     "n/a",
-		GameFolder:  "n/a",
-		GameName:    "n/a",
-		Environment: environmentFromRuntime(runtime.GOOS),
+func (q *QueryResponder) handleInfoRequest(clientAddress string, buf []byte) ([]byte, error) {
+	info, err := parseInfoRequest(buf)
+	if err != nil {
+		return nil, err
 	}
 
-	if q.state != nil {
-		f.ServerName = q.state.ServerName
-		f.GameMap = q.state.Map
-		f.PlayerCount = byte(atomic.LoadInt32(&q.state.CurrentPlayers))
-		f.MaxPlayers = byte(q.state.MaxPlayers)
-		f.GameName = q.state.GameType
+	var f any
+
+	// If no challenge has been supplied, respond with one. Expect it on the next request.
+	if info.Challenge == 0 {
+		challenge, handleErr := q.GenerateChallenge(clientAddress)
+		if handleErr != nil {
+			return nil, handleErr
+		}
+
+		f = challengeWireFormat{
+			Header:    s2cChallengeResponse,
+			Challenge: challenge,
+		}
+	} else {
+		if err = q.ChallengeMatchesForClient(clientAddress, info.Challenge); err != nil {
+			return nil, err
+		}
+
+		w := infoWireFormat{
+			Header:      a2sInfoResponse,
+			Protocol:    1,
+			ServerName:  "n/a",
+			GameMap:     "n/a",
+			GameFolder:  "n/a",
+			GameName:    "n/a",
+			Environment: environmentFromRuntime(runtime.GOOS),
+		}
+
+		if q.State != nil {
+			w.ServerName = q.State.ServerName
+			w.GameMap = q.State.Map
+			w.PlayerCount = byte(atomic.LoadInt32(&q.State.CurrentPlayers))
+			w.MaxPlayers = byte(q.State.MaxPlayers)
+			w.GameName = q.State.GameType
+		}
+
+		f = w
 	}
+
+	resp := bytes.NewBuffer(nil)
 
 	if err := proto.WireWrite(resp, q.enc, f); err != nil {
 		return nil, err
 	}
 
 	return resp.Bytes(), nil
+}
+
+// parseInfoRequest parses the incoming request as a A2S_INFO request.
+func parseInfoRequest(buf []byte) (*infoRequest, error) {
+	if !bytes.Equal(buf[0:5], a2sInfoRequest) {
+		return nil, errNotAnInfoRequest
+	}
+
+	info := &infoRequest{}
+	rBuf := bytes.NewBuffer(buf[5:])
+
+	// Read through buffer until we reach a null-terminator
+	n := 5
+	for n < len(buf) {
+		if buf[n] == 0 {
+			break
+		}
+		n++
+	}
+
+	// Read the payload if it exists
+	l := n - 5
+	if l > 0 {
+		d := make([]byte, l)
+		if err := binary.Read(rBuf, binary.LittleEndian, &d); err != nil {
+			return nil, err
+		}
+
+		info.Payload = string(d)
+	}
+
+	// Skip past null terminator
+	_ = rBuf.Next(1)
+	n++
+
+	// No space for a challenge - return as-is.
+	if n >= len(buf) {
+		return info, nil
+	}
+
+	if err := binary.Read(rBuf, binary.LittleEndian, &info.Challenge); err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 // environmentFromRuntime returns the environment byte required for the a2s response backend based upon the operating

--- a/game-server-hosting/server/proto/a2s/a2s_test.go
+++ b/game-server-hosting/server/proto/a2s/a2s_test.go
@@ -2,6 +2,8 @@ package a2s
 
 import (
 	"bytes"
+	"encoding/binary"
+	"io"
 	"runtime"
 	"testing"
 
@@ -21,8 +23,28 @@ func Test_Respond(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
-	// Query packet
-	resp, err := q.Respond("", a2sInfoRequest)
+	clientAddr := "my-client:1234"
+
+	// Query packet to receive challenge
+	qResp, err := q.Respond(clientAddr, a2sInfoRequest)
+	require.NoError(t, err)
+	require.Equal(t, s2cChallengeResponse, qResp[0:5])
+
+	// Expect challenge response
+	var challenge uint32
+	require.NoError(t, binary.Read(bytes.NewBuffer(qResp), binary.LittleEndian, &challenge))
+	require.True(t, challenge != 0)
+
+	// Query packet with challenge included
+	req := bytes.Join(
+		[][]byte{
+			a2sInfoRequest,
+			{0x0},      // payload
+			qResp[5:9], // challenge
+		},
+		nil,
+	)
+	resp, err := q.Respond(clientAddr, req)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -56,4 +78,97 @@ func Test_environmentFromRuntime(t *testing.T) {
 	require.Equal(t, byte('w'), environmentFromRuntime("windows"))
 	require.Equal(t, byte('l'), environmentFromRuntime("linux"))
 	require.Equal(t, byte('l'), environmentFromRuntime("foo"))
+}
+
+func Test_parseInfoRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         []byte
+		expected      *infoRequest
+		expectedError error
+	}{
+		{
+			name: "golden path",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+					[]byte("hello payload\x00"),
+					{1, 0, 0, 0},
+				},
+				nil,
+			),
+			expected: &infoRequest{
+				Payload:   "hello payload",
+				Challenge: 1,
+			},
+		},
+		{
+			name: "no payload",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+				},
+				nil,
+			),
+			expected: &infoRequest{},
+		},
+		{
+			name: "one byte payload",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+					[]byte("\x00"),
+				},
+				nil,
+			),
+			expected: &infoRequest{},
+		},
+		{
+			name: "no challenge",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+					[]byte("hello payload\x00"),
+				},
+				nil,
+			),
+			expected: &infoRequest{
+				Payload: "hello payload",
+			},
+		},
+		{
+			name: "no nil terminator",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+					[]byte("hello payload"),
+				},
+				nil,
+			),
+			expected: &infoRequest{
+				Payload: "hello payload",
+			},
+		},
+		{
+			name: "insufficient challenge bytes",
+			input: bytes.Join(
+				[][]byte{
+					{0xFF, 0xFF, 0xFF, 0xFF, 0x54},
+					[]byte("hello payload\x00"),
+					{1, 0, 0},
+				},
+				nil,
+			),
+			expectedError: io.ErrUnexpectedEOF,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := parseInfoRequest(tt.input)
+			require.ErrorIs(t, err, tt.expectedError)
+			require.Equal(t, tt.expected, info)
+		})
+	}
 }

--- a/game-server-hosting/server/proto/a2s/errors.go
+++ b/game-server-hosting/server/proto/a2s/errors.go
@@ -1,6 +1,9 @@
 package a2s
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type (
 	// UnsupportedQueryError is an error which represents an invalid SQP query header.
@@ -8,6 +11,9 @@ type (
 		header []byte
 	}
 )
+
+// errNotAnInfoRequest defines an error in which the input is not an A2S_INFO request.
+var errNotAnInfoRequest = errors.New("not an info request")
 
 // NewUnsupportedQueryError returns a new instance of UnsupportedQueryError.
 func NewUnsupportedQueryError(header []byte) error {

--- a/game-server-hosting/server/proto/base.go
+++ b/game-server-hosting/server/proto/base.go
@@ -1,0 +1,96 @@
+package proto
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"time"
+)
+
+type (
+	// QueryBase is the base querying struct which can be used by other implementers to handle features such as
+	// challenge generation.
+	QueryBase struct {
+		challenges               sync.Map
+		challengesLastPurgedUTC  time.Time
+		challengesLastPurgedLock sync.RWMutex
+
+		State *QueryState
+	}
+
+	// challengeEntry represents an entry in the query responder challenges map.
+	challengeEntry struct {
+		value     uint32
+		expiryUTC time.Time
+	}
+)
+
+var (
+	ErrChallengeMalformed = errors.New("challenge malformed")
+	ErrChallengeMismatch  = errors.New("challenge mismatch")
+	ErrNoChallenge        = errors.New("no challenge")
+)
+
+// GenerateChallenge generates a challenge value for the calling client address. If stale challenges have not been purged
+// for a while, this is done asynchronously.
+func (q *QueryBase) GenerateChallenge(clientAddress string) (uint32, error) {
+	// Purge entries asynchronously if we haven't done so in a while.
+	// Do this at the beginning so that any upcoming failures don't stop us from cleaning up.
+	q.challengesLastPurgedLock.RLock()
+	if time.Since(q.challengesLastPurgedUTC).Minutes() > 0 {
+		q.challengesLastPurgedLock.RUnlock()
+		q.challengesLastPurgedLock.Lock()
+		q.challengesLastPurgedUTC = time.Now().UTC()
+		q.challengesLastPurgedLock.Unlock()
+		q.challengesLastPurgedLock.RLock()
+		go q.purgeStaleChallenges(time.Now().UTC())
+	}
+	q.challengesLastPurgedLock.RUnlock()
+
+	randBytes := make([]byte, 4)
+	if _, err := rand.Read(randBytes); err != nil {
+		return 0, err
+	}
+
+	v := binary.BigEndian.Uint32(randBytes)
+	q.challenges.Store(clientAddress, challengeEntry{
+		value:     v,
+		expiryUTC: time.Now().UTC().Add(1 * time.Minute),
+	})
+
+	return v, nil
+}
+
+// ChallengeMatchesForClient determines whether the challenge value supplied by the client matches what is stored
+// by this server.
+func (q *QueryBase) ChallengeMatchesForClient(clientAddress string, challenge uint32) error {
+	expectedChallenge, ok := q.challenges.LoadAndDelete(clientAddress)
+	if !ok {
+		return ErrNoChallenge
+	}
+
+	expectedChallengeEntry, ok := expectedChallenge.(challengeEntry)
+	if !ok {
+		return ErrChallengeMalformed
+	}
+
+	if challenge != expectedChallengeEntry.value {
+		return ErrChallengeMismatch
+	}
+
+	return nil
+}
+
+// purgeStaleChallenges purges any entries which have an expiry in the past.
+func (q *QueryBase) purgeStaleChallenges(epochUTC time.Time) {
+	q.challenges.Range(func(k any, v any) bool {
+		if entry, ok := v.(challengeEntry); ok {
+			if epochUTC.After(entry.expiryUTC) {
+				q.challenges.Delete(k)
+			}
+		}
+
+		return true
+	})
+}

--- a/game-server-hosting/server/proto/base_test.go
+++ b/game-server-hosting/server/proto/base_test.go
@@ -1,0 +1,57 @@
+package proto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GenerateAndMatchChallenge(t *testing.T) {
+	t.Parallel()
+
+	q := &QueryBase{}
+
+	// Add a stale challenge to make sure the responder cleans it up.
+	const staleKey = "stale-challenge"
+	q.challenges.Store(staleKey, challengeEntry{
+		expiryUTC: time.Now().Add(-1 * time.Hour),
+	})
+
+	// Generate a challenge, make sure a mismatch returns as such
+	const clientAddr = "client-addr:1234"
+	c, err := q.GenerateChallenge(clientAddr)
+	require.NoError(t, err)
+	require.ErrorIs(t, q.ChallengeMatchesForClient(clientAddr, c+1), ErrChallengeMismatch)
+
+	// Generate a challenge, make sure it has been stored properly
+	c, err = q.GenerateChallenge(clientAddr)
+	require.NoError(t, err)
+	require.NoError(t, q.ChallengeMatchesForClient(clientAddr, c))
+
+	// Ensure stale key has been purged
+	require.Eventually(t, func() bool {
+		_, ok := q.challenges.Load(staleKey)
+		return !ok
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func Test_purgeStaleChallenges(t *testing.T) {
+	t.Parallel()
+
+	q := &QueryBase{}
+	now := time.Now().UTC()
+	q.challenges.Store("127.0.0.1", challengeEntry{expiryUTC: now.Add(-1 * time.Minute)})
+	q.challenges.Store("127.0.0.2", challengeEntry{expiryUTC: now.Add(1 * time.Minute)})
+	q.challenges.Store("127.0.0.3", challengeEntry{expiryUTC: now.Add(-1 * time.Hour)})
+
+	q.purgeStaleChallenges(now)
+
+	keys := make([]string, 0)
+	q.challenges.Range(func(key any, _ any) bool {
+		keys = append(keys, key.(string))
+		return true
+	})
+
+	require.Equal(t, []string{"127.0.0.2"}, keys)
+}

--- a/game-server-hosting/server/proto/sqp/errors.go
+++ b/game-server-hosting/server/proto/sqp/errors.go
@@ -13,11 +13,8 @@ type (
 )
 
 var (
-	ErrChallengeMalformed  = errors.New("challenge malformed")
-	ErrChallengeMismatch   = errors.New("challenge mismatch")
-	ErrInvalidPacketLength = errors.New("invalid packet length")
-	ErrNoChallenge         = errors.New("no challenge")
-	ErrUnsupportedQuery    = errors.New("unsupported query")
+	errInvalidPacketLength = errors.New("invalid packet length")
+	errUnsupportedQuery    = errors.New("unsupported query")
 )
 
 // NewUnsupportedSQPVersionError returns a new instance of UnsupportedSQPVersionError.

--- a/game-server-hosting/server/query.go
+++ b/game-server-hosting/server/query.go
@@ -80,7 +80,7 @@ func (s *Server) restartQueryEndpoint(c Config) error {
 
 // handleQuery handles responding to query commands on an incoming UDP port.
 func (s *Server) handleQuery() {
-	buf := make([]byte, 16)
+	buf := make([]byte, s.queryReadBufferSizeBytes)
 
 	s.wg.Add(1)
 	defer s.wg.Done()


### PR DESCRIPTION
Support the `S2C_CHALLENGE` response to prevent a reflection amplification attack as defined in the documentation: https://developer.valvesoftware.com/wiki/Server_queries#Request_Format. Part of this involved refactoring the query handling to make it more generic. Additionally, allocate `queryReadBufferSizeBytes` for the query buffer, so we can read the maximum amount of data configured to be read in the query handler.