### PR TITLE
feat(sqp): Support metrics chunk

### DIFF
--- a/game-server-hosting/server/internal/localproxy/client.go
+++ b/game-server-hosting/server/internal/localproxy/client.go
@@ -2,6 +2,7 @@ package localproxy
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ type Client struct {
 	centrifugeClient *centrifuge.Client
 	sub              *centrifuge.Subscription
 	host             string
+	httpClient       *http.Client
 	serverID         int64
 	callbacks        map[EventType]func(Event)
 	done             chan struct{}
@@ -29,6 +31,7 @@ func New(host string, serverID int64, chanError chan<- error) (*Client, error) {
 			centrifuge.DefaultConfig(),
 		),
 		host:           host,
+		httpClient:     &http.Client{},
 		serverID:       serverID,
 		callbacks:      map[EventType]func(Event){},
 		done:           make(chan struct{}),

--- a/game-server-hosting/server/internal/localproxy/reserve.go
+++ b/game-server-hosting/server/internal/localproxy/reserve.go
@@ -42,8 +42,7 @@ func (c *Client) ReserveSelf(ctx context.Context, args *model.ReserveRequest) (*
 	req.Header.Add("X-Request-ID", requestID.String())
 
 	var resp *http.Response
-	httpClient := &http.Client{}
-	if resp, err = httpClient.Do(req); err != nil {
+	if resp, err = c.httpClient.Do(req); err != nil {
 		return nil, fmt.Errorf("error making request: %w", err)
 	}
 

--- a/game-server-hosting/server/internal/localproxy/unreserve.go
+++ b/game-server-hosting/server/internal/localproxy/unreserve.go
@@ -35,8 +35,7 @@ func (c *Client) UnreserveSelf(ctx context.Context) error {
 	req.Header.Add("X-Request-ID", requestID.String())
 
 	var resp *http.Response
-	httpClient := &http.Client{}
-	if resp, err = httpClient.Do(req); err != nil {
+	if resp, err = c.httpClient.Do(req); err != nil {
 		return fmt.Errorf("error making request: %w", err)
 	}
 

--- a/game-server-hosting/server/proto/query.go
+++ b/game-server-hosting/server/proto/query.go
@@ -27,6 +27,7 @@ type (
 		GameType       string
 		Map            string
 		Port           uint16
+		Metrics        []float32
 	}
 )
 

--- a/game-server-hosting/server/proto/sqp/errors.go
+++ b/game-server-hosting/server/proto/sqp/errors.go
@@ -8,7 +8,7 @@ import (
 type (
 	// UnsupportedSQPVersionError is an error which represents an invalid SQP version provided to the reader.
 	UnsupportedSQPVersionError struct {
-		version int8
+		version uint16
 	}
 )
 
@@ -18,7 +18,7 @@ var (
 )
 
 // NewUnsupportedSQPVersionError returns a new instance of UnsupportedSQPVersionError.
-func NewUnsupportedSQPVersionError(version int8) error {
+func NewUnsupportedSQPVersionError(version uint16) error {
 	return &UnsupportedSQPVersionError{
 		version: version,
 	}

--- a/game-server-hosting/server/proto/sqp/metrics_info.go
+++ b/game-server-hosting/server/proto/sqp/metrics_info.go
@@ -1,0 +1,36 @@
+package sqp
+
+import (
+	"math"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/proto"
+)
+
+type (
+	// sqpMetricsInfo holds the server metrics chunk data.
+	sqpMetricsInfo struct {
+		Count  byte
+		Values []float32
+	}
+)
+
+// MaxMetrics represents the maximum number of metrics one SQP packet supports.
+const MaxMetrics = 10
+
+// queryStateToMetrics converts metrics data in provided query state to sqpMetricsInfo.
+func queryStateToMetrics(qs *proto.QueryState) *sqpMetricsInfo {
+	l := byte(math.Min(float64(len(qs.Metrics)), float64(MaxMetrics)))
+	m := &sqpMetricsInfo{
+		Count: l,
+	}
+
+	m.Values = make([]float32, l)
+	copy(m.Values, qs.Metrics)
+
+	return m
+}
+
+// Size returns the number of bytes QueryResponder will use on the wire.
+func (m sqpMetricsInfo) Size() uint32 {
+	return uint32(1 + len(m.Values)*4)
+}

--- a/game-server-hosting/server/proto/sqp/server_info.go
+++ b/game-server-hosting/server/proto/sqp/server_info.go
@@ -7,6 +7,7 @@ import (
 )
 
 type (
+	// sqpServerInfo holds the server info chunk data.
 	sqpServerInfo struct {
 		CurrentPlayers uint16
 		MaxPlayers     uint16
@@ -19,16 +20,16 @@ type (
 )
 
 // queryStateToServerInfo converts proto.QueryState to sqpServerInfo.
-func queryStateToServerInfo(qs *proto.QueryState) sqpServerInfo {
+func queryStateToServerInfo(qs *proto.QueryState) *sqpServerInfo {
 	if qs == nil {
-		return sqpServerInfo{
+		return &sqpServerInfo{
 			ServerName: "n/a",
 			GameType:   "n/a",
 			GameMap:    "n/a",
 		}
 	}
 
-	return sqpServerInfo{
+	return &sqpServerInfo{
 		CurrentPlayers: uint16(atomic.LoadInt32(&qs.CurrentPlayers)),
 		MaxPlayers:     uint16(qs.MaxPlayers),
 		ServerName:     qs.ServerName,

--- a/game-server-hosting/server/proto/sqp/sqp_test.go
+++ b/game-server-hosting/server/proto/sqp/sqp_test.go
@@ -2,22 +2,31 @@ package sqp
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/proto"
 	"github.com/stretchr/testify/require"
 )
 
+const addrKey = "client-addr:65534"
+
 func Test_Respond(t *testing.T) {
 	t.Parallel()
 	q, err := NewQueryResponder(&proto.QueryState{
 		CurrentPlayers: 1,
 		MaxPlayers:     2,
+		Metrics:        make([]float32, 1, MaxMetrics),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
-	addr := "client-addr:65534"
+	// Set a metric value.
+	metricBytes := bytes.NewBuffer(nil)
+	q.State.Metrics[0] = 1.234
+	require.NoError(t, binary.Write(metricBytes, binary.BigEndian, q.State.Metrics[0]))
+
+	addr := addrKey
 
 	// Challenge packet
 	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})
@@ -30,9 +39,9 @@ func Test_Respond(t *testing.T) {
 		bytes.Join(
 			[][]byte{
 				{1},
-				resp[1:5], // challenge
-				{0, 1},    // SQP version
-				{1},       // Request chunks (server info only)
+				resp[1:5],    // challenge
+				{0, 2},       // SQP version
+				{0b00010001}, // Request chunks (server and metrics info)
 			},
 			nil,
 		),
@@ -47,7 +56,165 @@ func Test_Respond(t *testing.T) {
 				resp[5:7],
 				{0},
 				{0},
-				{0x0, 0xe, 0x0, 0x0, 0x0, 0xa, 0x0, 0x1, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+				{0x0, 0x17},
+				// Server Info chunk
+				{0x0, 0x0, 0x0, 0xa, 0x0, 0x1, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+				// Metrics chunk
+				{0x0, 0x0, 0x0, 0x5, 0x1},
+				metricBytes.Bytes(),
+			},
+			nil,
+		),
+		resp,
+	)
+}
+
+func Test_Respond_ServerInfoOnly(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	addr := addrKey
+
+	// Challenge packet
+	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})
+	require.NoError(t, err)
+	require.Equal(t, byte(0), resp[0])
+
+	// Query packet
+	resp, err = q.Respond(
+		addr,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],    // challenge
+				{0, 1},       // SQP version
+				{0b00000001}, // Request chunks (server info only)
+			},
+			nil,
+		),
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],
+				resp[5:7],
+				{0},
+				{0},
+				{0x0, 0xe},
+				// Server Info chunk
+				{0x0, 0x0, 0x0, 0xa, 0x0, 0x1, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			},
+			nil,
+		),
+		resp,
+	)
+}
+
+func Test_Respond_MetricsOnly(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+		Metrics:        make([]float32, 1, MaxMetrics),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	// Set a metric value.
+	metricBytes := bytes.NewBuffer(nil)
+	q.State.Metrics[0] = 1.234
+	require.NoError(t, binary.Write(metricBytes, binary.BigEndian, q.State.Metrics[0]))
+
+	addr := addrKey
+
+	// Challenge packet
+	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})
+	require.NoError(t, err)
+	require.Equal(t, byte(0), resp[0])
+
+	// Query packet
+	resp, err = q.Respond(
+		addr,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],    // challenge
+				{0, 2},       // SQP version
+				{0b00010000}, // Request chunks (metrics info only)
+			},
+			nil,
+		),
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],
+				resp[5:7],
+				{0},
+				{0},
+				{0x0, 0x9},
+				// Metrics chunk
+				{0x0, 0x0, 0x0, 0x5, 0x1},
+				metricBytes.Bytes(),
+			},
+			nil,
+		),
+		resp,
+	)
+}
+
+func Test_Respond_NoMetricsInVersion1(t *testing.T) {
+	t.Parallel()
+	q, err := NewQueryResponder(&proto.QueryState{
+		CurrentPlayers: 1,
+		MaxPlayers:     2,
+		Metrics:        make([]float32, 1, MaxMetrics),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	addr := addrKey
+
+	// Challenge packet
+	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})
+	require.NoError(t, err)
+	require.Equal(t, byte(0), resp[0])
+
+	// Query packet
+	resp, err = q.Respond(
+		addr,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],    // challenge
+				{0, 1},       // SQP version
+				{0b00010000}, // Request chunks (metrics info only)
+			},
+			nil,
+		),
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		bytes.Join(
+			[][]byte{
+				{1},
+				resp[1:5],
+				resp[5:7],
+				{0},
+				{0},
+				{0x0, 0x0},
 			},
 			nil,
 		),
@@ -89,7 +256,7 @@ func Test_Respond_mismatchedChallenge(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
-	addr := "client-addr:65534"
+	addr := addrKey
 
 	// Challenge packet
 	resp, err := q.Respond(addr, []byte{0, 0, 0, 0, 0})


### PR DESCRIPTION
Add support for SQP metrics chunk. Introduces a new method, `SetMetric(index byte, value float32)` on `Server` to enable SDK users to set arbitrary metrics up to the pre-defined limit.

Also, address a few comments from the previous PR.