### PR TITLE
fix: Remove code which handles starting with an allocation

### DIFF
--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -189,18 +189,6 @@ func (s *Server) Start() error {
 		return fmt.Errorf("error configuring event watcher: %w", err)
 	}
 
-	// Handle the app starting with an allocation
-	if c.AllocatedUUID != "" {
-		// Configuration has changed - propagate to consumer. This is optional, so make sure we don't deadlock if
-		// nobody is listening.
-		select {
-		case s.chanConfigurationChanged <- *c:
-		default:
-		}
-
-		s.chanAllocated <- c.AllocatedUUID
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This code is redundant now that we use event-based allocations. It was triggering a double-allocate, in error, on startup.