### PR TITLE
feat: Support Hold and Release in Go SDK

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,4 @@ linters:
     - structcheck
     - nosnakecase
     - lll
+    - dupl

--- a/game-server-hosting/server/internal/localproxy/error.go
+++ b/game-server-hosting/server/internal/localproxy/error.go
@@ -1,17 +1,10 @@
 package localproxy
 
-import "fmt"
-
-// UnexpectedResponseError represents an unexpected response from the local proxy.
-type UnexpectedResponseError struct {
-	RequestID    string
-	StatusCode   int
-	ResponseBody string
-}
+import "github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/model"
 
 // NewUnexpectedResponseWithBody creates a new UnexpectedResponseError from a response body.
-func NewUnexpectedResponseWithBody(requestID string, statusCode int, responseBody []byte) *UnexpectedResponseError {
-	return &UnexpectedResponseError{
+func NewUnexpectedResponseWithBody(requestID string, statusCode int, responseBody []byte) *model.UnexpectedResponseError {
+	return &model.UnexpectedResponseError{
 		RequestID:    requestID,
 		StatusCode:   statusCode,
 		ResponseBody: string(responseBody),
@@ -19,15 +12,10 @@ func NewUnexpectedResponseWithBody(requestID string, statusCode int, responseBod
 }
 
 // NewUnexpectedResponseWithError creates a new UnexpectedResponseError from an error.
-func NewUnexpectedResponseWithError(requestID string, statusCode int, err error) *UnexpectedResponseError {
-	return &UnexpectedResponseError{
+func NewUnexpectedResponseWithError(requestID string, statusCode int, err error) *model.UnexpectedResponseError {
+	return &model.UnexpectedResponseError{
 		RequestID:    requestID,
 		StatusCode:   statusCode,
 		ResponseBody: err.Error(),
 	}
-}
-
-// Error returns the string representation of the error.
-func (e *UnexpectedResponseError) Error() string {
-	return fmt.Sprintf("unexpected response from local proxy, request ID: %s, status: %d, error: %s", e.RequestID, e.StatusCode, e.ResponseBody)
 }

--- a/game-server-hosting/server/internal/localproxy/hold.go
+++ b/game-server-hosting/server/internal/localproxy/hold.go
@@ -1,0 +1,113 @@
+package localproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/model"
+	"github.com/google/uuid"
+)
+
+// HoldSelf triggers the local proxy endpoint to hold this server instance.
+func (c *Client) HoldSelf(ctx context.Context, args *model.HoldRequest) (*model.HoldStatus, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(args); err != nil {
+		return nil, fmt.Errorf("error encoding args: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/v1/servers/%d/hold", c.host, c.serverID),
+		buf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Add a request ID - if we cannot generate a UUID for any reason, just populate an empty one.
+	requestID, err := uuid.NewUUID()
+	if err != nil {
+		requestID = uuid.UUID{}
+	}
+	req.Header.Add("X-Request-ID", requestID.String())
+
+	var resp *http.Response
+	if resp, err = c.httpClient.Do(req); err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, NewUnexpectedResponseWithError(requestID.String(), resp.StatusCode, readErr)
+		}
+		return nil, NewUnexpectedResponseWithBody(requestID.String(), resp.StatusCode, body)
+	}
+
+	var body *model.HoldStatus
+	if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	return body, nil
+}
+
+// HoldStatus triggers the local proxy endpoint to get the status of the hold for this server instance.
+func (c *Client) HoldStatus(ctx context.Context) (*model.HoldStatus, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("%s/v1/servers/%d/hold", c.host, c.serverID),
+		http.NoBody,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Add a request ID - if we cannot generate a UUID for any reason, just populate an empty one.
+	requestID, err := uuid.NewUUID()
+	if err != nil {
+		requestID = uuid.UUID{}
+	}
+	req.Header.Add("X-Request-ID", requestID.String())
+
+	var resp *http.Response
+	if resp, err = c.httpClient.Do(req); err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, NewUnexpectedResponseWithError(requestID.String(), resp.StatusCode, readErr)
+		}
+		return nil, NewUnexpectedResponseWithBody(requestID.String(), resp.StatusCode, body)
+	}
+
+	var body *model.HoldStatus
+	if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	return body, nil
+}

--- a/game-server-hosting/server/internal/localproxy/hold_test.go
+++ b/game-server-hosting/server/internal/localproxy/hold_test.go
@@ -1,0 +1,44 @@
+package localproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/model"
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/internal/localproxytest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_HoldSelf(t *testing.T) {
+	t.Parallel()
+
+	svr, err := localproxytest.NewLocalProxy()
+	require.NoError(t, err)
+	defer svr.Close()
+
+	chanError := make(chan error, 1)
+	c, err := New(svr.Host, 1, chanError)
+	require.NoError(t, err)
+
+	resp, err := c.HoldSelf(context.Background(), &model.HoldRequest{
+		Timeout: "10m",
+	})
+	require.NoError(t, err)
+	require.Equal(t, svr.HoldStatus, resp)
+}
+
+func Test_HoldStatus(t *testing.T) {
+	t.Parallel()
+
+	svr, err := localproxytest.NewLocalProxy()
+	require.NoError(t, err)
+	defer svr.Close()
+
+	chanError := make(chan error, 1)
+	c, err := New(svr.Host, 1, chanError)
+	require.NoError(t, err)
+
+	resp, err := c.HoldStatus(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, svr.HoldStatus, resp)
+}

--- a/game-server-hosting/server/internal/localproxy/release.go
+++ b/game-server-hosting/server/internal/localproxy/release.go
@@ -1,0 +1,53 @@
+package localproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ReleaseSelf triggers the local proxy endpoint to release the hold on this server instance.
+func (c *Client) ReleaseSelf(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodDelete,
+		fmt.Sprintf("%s/v1/servers/%d/hold", c.host, c.serverID),
+		http.NoBody,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Add a request ID - if we cannot generate a UUID for any reason, just populate an empty one.
+	requestID, err := uuid.NewUUID()
+	if err != nil {
+		requestID = uuid.UUID{}
+	}
+	req.Header.Add("X-Request-ID", requestID.String())
+
+	var resp *http.Response
+	if resp, err = c.httpClient.Do(req); err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return NewUnexpectedResponseWithError(requestID.String(), resp.StatusCode, readErr)
+		}
+		return NewUnexpectedResponseWithBody(requestID.String(), resp.StatusCode, body)
+	}
+
+	return nil
+}

--- a/game-server-hosting/server/internal/localproxy/release_test.go
+++ b/game-server-hosting/server/internal/localproxy/release_test.go
@@ -1,0 +1,23 @@
+package localproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/internal/localproxytest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ReleaseSelf(t *testing.T) {
+	t.Parallel()
+
+	svr, err := localproxytest.NewLocalProxy()
+	require.NoError(t, err)
+	defer svr.Close()
+
+	chanError := make(chan error, 1)
+	c, err := New(svr.Host, 1, chanError)
+	require.NoError(t, err)
+
+	require.NoError(t, c.ReleaseSelf(context.Background()))
+}

--- a/game-server-hosting/server/model/error.go
+++ b/game-server-hosting/server/model/error.go
@@ -1,0 +1,15 @@
+package model
+
+import "fmt"
+
+// UnexpectedResponseError represents an unexpected response from the local proxy.
+type UnexpectedResponseError struct {
+	RequestID    string
+	StatusCode   int
+	ResponseBody string
+}
+
+// Error returns the string representation of the error.
+func (e *UnexpectedResponseError) Error() string {
+	return fmt.Sprintf("unexpected response from local proxy, request ID: %s, status: %d, error: %s", e.RequestID, e.StatusCode, e.ResponseBody)
+}

--- a/game-server-hosting/server/model/hold_release.go
+++ b/game-server-hosting/server/model/hold_release.go
@@ -1,0 +1,18 @@
+package model
+
+type (
+	// HoldRequest defines the model for the request to hold a server.
+	HoldRequest struct {
+		// The duration of the server hold. Formatted as a duration string with a sequence of numbers and time units (e.g. 2m / 1h).
+		// Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Holds are stored at a per-second granularity.
+		Timeout string `json:"timeout"`
+	}
+
+	// HoldStatus defines the model for the status of server hold, returned from a successful hold request or status request.
+	HoldStatus struct {
+		// The unix epoch when the hold will automatically expire, in seconds.
+		ExpiresAt int64 `json:"expiresAt"`
+		// Whether the server is currently held.
+		Held bool `json:"held"`
+	}
+)

--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -271,6 +271,31 @@ func (s *Server) Unreserve(ctx context.Context) error {
 	return s.localProxyClient.UnreserveSelf(ctx)
 }
 
+// Hold holds this server, preventing descaling until after a reservation completes, the expiry time elapses,
+// or the hold is manually released with the Release() method.
+func (s *Server) Hold(ctx context.Context, args *model.HoldRequest) (*model.HoldStatus, error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	return s.localProxyClient.HoldSelf(ctx, args)
+}
+
+// HoldStatus gets the status of the hold for the server, including the time at which the hold expires.
+func (s *Server) HoldStatus(ctx context.Context) (*model.HoldStatus, error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	return s.localProxyClient.HoldStatus(ctx)
+}
+
+// Release manually releases any existing holds for this server.
+func (s *Server) Release(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	return s.localProxyClient.ReleaseSelf(ctx)
+}
+
 // PlayerJoined indicates a new player has joined the server.
 func (s *Server) PlayerJoined() int32 {
 	s.stateLock.Lock()


### PR DESCRIPTION
Support `Hold()`, `HoldStatus()` and `Release()` methods in the Go SDK. These call equivalent localproxy APIs to trigger Hold & Release workflows.