### PR TITLE
feat: Add fleetID, machineID and regionID variables

### DIFF
--- a/game-server-hosting/server/config.go
+++ b/game-server-hosting/server/config.go
@@ -13,6 +13,9 @@ type (
 		// AllocatedUUID is the allocation ID provided to an event.
 		AllocatedUUID string `json:"allocatedUUID"`
 
+		// FleetID is the ID of the fleet this server is a member of.
+		FleetID string `json:"fleetID"`
+
 		// IP is the IPv4 address of this server.
 		IP string `json:"ip"`
 
@@ -21,6 +24,9 @@ type (
 
 		// LocalProxyURL is the URL to the local proxy service, which can handle interactions with the allocations payload store.
 		LocalProxyURL string `json:"localProxyUrl"`
+
+		// MachineID is the ID of the machine which this server is running on.
+		MachineID json.Number `json:"machineID"`
 
 		// Port is the port number this server uses for game interactions. It is up to the implemented to bind their game
 		// server to this port.
@@ -31,6 +37,9 @@ type (
 
 		// QueryType represents the query protocol used by this server.
 		QueryType QueryProtocol `json:"queryType"`
+
+		// RegionID is the ID of the region this server is a member of.
+		RegionID string `json:"regionID"`
 
 		// ServerID is the ID of the running server in the Unity Game Server Hosting platform.
 		ServerID json.Number `json:"serverID"`

--- a/game-server-hosting/server/config_test.go
+++ b/game-server-hosting/server/config_test.go
@@ -15,10 +15,13 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 		os.WriteFile(f, []byte(
 			`{
 				"allocatedUUID": "a-uuid",
+				"fleetID": "abcd",
 				"ip": "127.0.0.1",
 				"ipv6": "::1",
+				"machineID": "1234",
 				"port": "9000",
 				"queryPort": "9010",
+				"regionID": "efgh",
 				"serverID": "1234",
 				"serverLogDir": "/logs",
 				"a": "b"
@@ -32,12 +35,15 @@ func Test_NewConfigFromFile_defaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &Config{
 		AllocatedUUID: "a-uuid",
+		FleetID:       "abcd",
 		IP:            "127.0.0.1",
 		IPv6:          "::1",
 		LocalProxyURL: "http://localhost:8086",
+		MachineID:     "1234",
 		Port:          "9000",
 		QueryPort:     "9010",
 		QueryType:     QueryProtocolSQP,
+		RegionID:      "efgh",
 		ServerID:      "1234",
 		ServerLogDir:  "/logs",
 		Extra: map[string]string{
@@ -53,11 +59,14 @@ func Test_NewConfigFromFile_supported_values(t *testing.T) {
 		os.WriteFile(f, []byte(
 			`{
 				"allocatedUUID": "a-uuid",
+				"fleetID": "abcd",
 				"ip": "127.0.0.1",
 				"ipv6": "::1",
 				"localProxyUrl": "http://my-localproxy",
+				"machineID": "1234",
 				"port": "9000",
 				"queryPort": "9010",
+				"regionID": "efgh",
 				"serverID": "1234",
 				"serverLogDir": "/mnt/unity/logs/"
 			}`,
@@ -70,12 +79,15 @@ func Test_NewConfigFromFile_supported_values(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &Config{
 		AllocatedUUID: "a-uuid",
+		FleetID:       "abcd",
 		IP:            "127.0.0.1",
 		IPv6:          "::1",
 		LocalProxyURL: "http://my-localproxy",
+		MachineID:     "1234",
 		Port:          "9000",
 		QueryPort:     "9010",
 		QueryType:     QueryProtocolSQP,
+		RegionID:      "efgh",
 		ServerID:      "1234",
 		ServerLogDir:  "/mnt/unity/logs/",
 		Extra:         map[string]string{},


### PR DESCRIPTION
These variables are now available as part of the `server.json` file.