### PR TITLE
feat: Add SetCurrentPlayers

### DIFF
--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -314,6 +314,19 @@ func (s *Server) PlayerLeft() int32 {
 	return s.state.CurrentPlayers
 }
 
+// SetCurrentPlayers sets the number of players currently in the game. Can be used as an alternative to PlayerJoined
+// and PlayerLeft.
+func (s *Server) SetCurrentPlayers(players int32) {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+
+	if players < 0 {
+		players = 0
+	}
+
+	s.state.CurrentPlayers = players
+}
+
 // SetMaxPlayers sets the maximum players this server will host. It does not enforce this number,
 // it only serves for query / metrics.
 func (s *Server) SetMaxPlayers(max int32) {

--- a/game-server-hosting/server/server_test.go
+++ b/game-server-hosting/server/server_test.go
@@ -171,6 +171,19 @@ func Test_PlayerJoinedAndLeft(t *testing.T) {
 	require.Equal(t, int32(0), s.state.CurrentPlayers)
 }
 
+func Test_SetCurrentPlayers(t *testing.T) {
+	t.Parallel()
+
+	s, err := New(TypeAllocation)
+	require.NoError(t, err)
+
+	s.SetCurrentPlayers(10)
+	require.Equal(t, int32(10), s.state.CurrentPlayers)
+
+	s.SetCurrentPlayers(-1)
+	require.Equal(t, int32(0), s.state.CurrentPlayers)
+}
+
 func Test_DataSettings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add a new method, SetCurrentPlayers, which sets the player count to the number specified. This can be used as an alternative to PlayerJoined and PlayerLeft.