### PR TITLE
feat(gsh): implement ready for players

### DIFF
--- a/game-server-hosting/server/internal/localproxy/allocation.go
+++ b/game-server-hosting/server/internal/localproxy/allocation.go
@@ -1,0 +1,62 @@
+package localproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/model"
+	"github.com/google/uuid"
+)
+
+// PatchAllocation triggers the local proxy endpoint to patch this server allocation.
+func (c *Client) PatchAllocation(ctx context.Context, allocationID string, args *model.PatchAllocationRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(args); err != nil {
+		return fmt.Errorf("error encoding args: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPatch,
+		fmt.Sprintf("%s/v1/servers/%d/allocations/%s", c.host, c.serverID, allocationID),
+		buf,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Add a request ID - if we cannot generate a UUID for any reason, just populate an empty one.
+	requestID, err := uuid.NewUUID()
+	if err != nil {
+		requestID = uuid.UUID{}
+	}
+
+	req.Header.Add("X-Request-ID", requestID.String())
+
+	var resp *http.Response
+	if resp, err = c.httpClient.Do(req); err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return NewUnexpectedResponseWithError(requestID.String(), resp.StatusCode, readErr)
+		}
+		return NewUnexpectedResponseWithBody(requestID.String(), resp.StatusCode, body)
+	}
+
+	return nil
+}

--- a/game-server-hosting/server/internal/localproxy/allocation_test.go
+++ b/game-server-hosting/server/internal/localproxy/allocation_test.go
@@ -29,6 +29,7 @@ func Test_PatchAllocation(t *testing.T) {
 	alloc := "00000001-0000-0000-0000-000000000000"
 
 	require.NoError(t, c.PatchAllocation(ctx, alloc, args), "patching allocation")
-	require.NotNil(t, proxy.PatchAllocationRequest, "nil patch allocation request")
-	require.Equal(t, true, proxy.PatchAllocationRequest.Ready, "unexpected ready value")
+	require.Contains(t, proxy.PatchAllocationRequests, alloc, "missing patch allocation request")
+	require.NotNil(t, proxy.PatchAllocationRequests[alloc], "nil patch allocation request")
+	require.Equal(t, true, proxy.PatchAllocationRequests[alloc].Ready, "unexpected ready value")
 }

--- a/game-server-hosting/server/internal/localproxy/allocation_test.go
+++ b/game-server-hosting/server/internal/localproxy/allocation_test.go
@@ -1,0 +1,34 @@
+package localproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/model"
+	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/internal/localproxytest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PatchAllocation(t *testing.T) {
+	t.Parallel()
+
+	proxy, err := localproxytest.NewLocalProxy()
+	require.NoError(t, err, "creating local proxy")
+	defer proxy.Close()
+
+	chanError := make(chan error, 1)
+
+	c, err := New(proxy.Host, 1, chanError)
+	require.NoError(t, err)
+
+	args := &model.PatchAllocationRequest{
+		Ready: true,
+	}
+
+	ctx := context.Background()
+	alloc := "00000001-0000-0000-0000-000000000000"
+
+	require.NoError(t, c.PatchAllocation(ctx, alloc, args), "patching allocation")
+	require.NotNil(t, proxy.PatchAllocationRequest, "nil patch allocation request")
+	require.Equal(t, true, proxy.PatchAllocationRequest.Ready, "unexpected ready value")
+}

--- a/game-server-hosting/server/model/allocation.go
+++ b/game-server-hosting/server/model/allocation.go
@@ -1,0 +1,7 @@
+package model
+
+// PatchAllocationRequest defines the model for the request to patch a server allocation.
+type PatchAllocationRequest struct {
+	// Ready is the ready state of the server.
+	Ready bool `json:"ready"`
+}

--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -110,6 +110,9 @@ var (
 
 	// ErrMetricOutOfBounds represents that the metric index provided will overflow the metrics buffer.
 	ErrMetricOutOfBounds = errors.New("metrics index provided will overflow the metrics buffer")
+
+	/// ErrNotAllocated represents that the server is not allocated.
+	ErrNotAllocated = errors.New("server is not allocated")
 )
 
 // New creates a new instance of Server, denoting which type of server to use.
@@ -303,6 +306,10 @@ func (s *Server) ReadyForPlayers(ctx context.Context) error {
 	}
 
 	allocationID := s.currentConfig.AllocatedUUID
+	if allocationID == "" {
+		return ErrNotAllocated
+	}
+
 	patch := &model.PatchAllocationRequest{
 		Ready: true,
 	}

--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -296,6 +296,20 @@ func (s *Server) Release(ctx context.Context) error {
 	return s.localProxyClient.ReleaseSelf(ctx)
 }
 
+// ReadyForPlayers indicates the server is ready for players to join.
+func (s *Server) ReadyForPlayers(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	allocationID := s.currentConfig.AllocatedUUID
+	patch := &model.PatchAllocationRequest{
+		Ready: true,
+	}
+
+	return s.localProxyClient.PatchAllocation(ctx, allocationID, patch)
+}
+
 // PlayerJoined indicates a new player has joined the server.
 func (s *Server) PlayerJoined() int32 {
 	s.stateLock.Lock()

--- a/game-server-hosting/server/server_test.go
+++ b/game-server-hosting/server/server_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +17,6 @@ import (
 	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/proto"
 	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/game-server-hosting/server/proto/sqp"
 	"github.com/Unity-Technologies/unity-gaming-services-go-sdk/internal/localproxytest"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/localproxytest/server.go
+++ b/internal/localproxytest/server.go
@@ -32,6 +32,10 @@ type MockLocalProxy struct {
 
 	// HoldStatus is the status of a server hold, the response this mock uses.
 	HoldStatus *model.HoldStatus
+
+	// PatchAllocationRequest is the last request made to patch an allocation.
+	// This is used to verify the request body.
+	PatchAllocationRequest *model.PatchAllocationRequest
 }
 
 // NewLocalProxy sets up a new websocket server with centrifuge which accepts all connections and subscriptions.
@@ -124,8 +128,18 @@ func NewLocalProxy() (*MockLocalProxy, error) {
 			default:
 				w.WriteHeader(http.StatusMethodNotAllowed)
 			}
+
+		case "/v1/servers/1/allocations/00000001-0000-0000-0000-000000000000":
+			switch r.Method {
+			case http.MethodPatch:
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
 		}
 	}))
+
 	ip = ws.URL
 
 	return &MockLocalProxy{


### PR DESCRIPTION
This PR implements the Ready for Players method to support the Server Readiness feature.
