### PR TITLE
chore(server): use local variable for alloc ID

### DIFF
--- a/game-server-hosting/server/event_watcher.go
+++ b/game-server-hosting/server/event_watcher.go
@@ -56,6 +56,10 @@ func (s *Server) listenForEvents() {
 // channel when signalled.
 func (s *Server) watchAllocation(ev localproxy.Event) {
 	if ae, ok := ev.(*localproxy.AllocateEvent); ok {
+		s.allocatedUUIDMtx.Lock()
+		s.allocatedUUID = ae.AllocationID
+		s.allocatedUUIDMtx.Unlock()
+
 		s.chanAllocated <- ae.AllocationID
 	}
 }
@@ -64,6 +68,10 @@ func (s *Server) watchAllocation(ev localproxy.Event) {
 // channel when signalled.
 func (s *Server) watchDeallocation(ev localproxy.Event) {
 	if de, ok := ev.(*localproxy.DeallocateEvent); ok {
+		s.allocatedUUIDMtx.Lock()
+		s.allocatedUUID = de.AllocationID
+		s.allocatedUUIDMtx.Unlock()
+
 		s.chanDeallocated <- de.AllocationID
 	}
 }

--- a/game-server-hosting/server/server.go
+++ b/game-server-hosting/server/server.go
@@ -23,6 +23,10 @@ type (
 
 	// Server represents an instance of a game server, handling changes to configuration and responding to query requests.
 	Server struct {
+		// AllocatedUUID is the allocation ID provided to an event.
+		allocatedUUID    string
+		allocatedUUIDMtx sync.RWMutex
+
 		// cfgFile is the file path this game uses to read its configuration from
 		cfgFile string
 
@@ -305,7 +309,10 @@ func (s *Server) ReadyForPlayers(ctx context.Context) error {
 		return ErrNilContext
 	}
 
-	allocationID := s.currentConfig.AllocatedUUID
+	s.allocatedUUIDMtx.RLock()
+	allocationID := s.allocatedUUID
+	s.allocatedUUIDMtx.RUnlock()
+
 	if allocationID == "" {
 		return ErrNotAllocated
 	}

--- a/game-server-hosting/server/server_test.go
+++ b/game-server-hosting/server/server_test.go
@@ -430,13 +430,13 @@ func Test_ReadyForPlayers(t *testing.T) {
 	port := strings.Split(queryEndpoint, ":")[1]
 
 	data := []byte(fmt.Sprintf(`{
-		"allocatedUUID": "%s",
+		"allocatedUUID": "",
 		"localProxyUrl": "%s",
 		"queryPort": "%s",
 		"queryType": "sqp",
 		"serverID": "1",
 		"serverLogDir": "%s"
-	}`, alloc, proxy.Host, port, filepath.Join(dir, "logs")))
+	}`, proxy.Host, port, filepath.Join(dir, "logs")))
 
 	configPath := filepath.Join(dir, "server.json")
 	require.NoError(t, os.WriteFile(configPath, data, 0o600), "writing config file")
@@ -444,6 +444,10 @@ func Test_ReadyForPlayers(t *testing.T) {
 	s, err := New(TypeAllocation, WithConfigPath(configPath))
 	require.NoError(t, err, "making test server")
 	require.NotNil(t, s, "nil test server")
+
+	s.allocatedUUIDMtx.Lock()
+	s.allocatedUUID = alloc
+	s.allocatedUUIDMtx.Unlock()
 
 	require.NoError(t, s.Start(), "starting test server")
 


### PR DESCRIPTION
This change updates the allocate and deallocate flows to store the allocation ID as a variable of the server object. 