### PR TITLE
fix(a2s): Added missing ServerType field to response

### DIFF
--- a/game-server-hosting/server/proto/a2s/a2s.go
+++ b/game-server-hosting/server/proto/a2s/a2s.go
@@ -106,6 +106,7 @@ func (q *QueryResponder) handleInfoRequest(clientAddress string, buf []byte) ([]
 			GameMap:     "n/a",
 			GameFolder:  "n/a",
 			GameName:    "n/a",
+			ServerType:  'd', // d = dedicated server
 			Environment: environmentFromRuntime(runtime.GOOS),
 		}
 

--- a/game-server-hosting/server/proto/a2s/a2s.go
+++ b/game-server-hosting/server/proto/a2s/a2s.go
@@ -106,7 +106,7 @@ func (q *QueryResponder) handleInfoRequest(clientAddress string, buf []byte) ([]
 			GameMap:     "n/a",
 			GameFolder:  "n/a",
 			GameName:    "n/a",
-			ServerType:  'd', // d = dedicated server
+			ServerType:  'd', // d = dedicated server, which is the only supported option currently
 			Environment: environmentFromRuntime(runtime.GOOS),
 		}
 

--- a/game-server-hosting/server/proto/a2s/a2s_test.go
+++ b/game-server-hosting/server/proto/a2s/a2s_test.go
@@ -60,7 +60,7 @@ func Test_Respond(t *testing.T) {
 				{1},
 				{2},
 				{0},
-				{0},
+				{'d'},
 				{environmentFromRuntime(runtime.GOOS)},
 				{0},
 				{0},


### PR DESCRIPTION
The a2s implementation was missing `ServerType`, causing it to default to `NULL`. This was a bug as the only supported values are `'d'` (dedicated server), `'l'` (non-dedicated server), or `'p'` (proxy). I've set it to return `'d'` as that is the only offering from Multiplay Hosting.