### PR TITLE
fix(a2s): Added missing string field Version to payload

### DIFF
--- a/game-server-hosting/server/proto/a2s/a2s.go
+++ b/game-server-hosting/server/proto/a2s/a2s.go
@@ -38,6 +38,7 @@ type (
 		Environment byte
 		Visibility  byte
 		VACEnabled  byte
+		Version     string
 	}
 
 	// infoRequest represents the request format for an A2S_INFO query.

--- a/game-server-hosting/server/proto/a2s/a2s_test.go
+++ b/game-server-hosting/server/proto/a2s/a2s_test.go
@@ -64,6 +64,7 @@ func Test_Respond(t *testing.T) {
 				{environmentFromRuntime(runtime.GOOS)},
 				{0},
 				{0},
+				{0},
 			},
 			nil,
 		),


### PR DESCRIPTION
Found an additional missing field, Version (referring to the game's version). Leaving it as the empty string as this is not information we'd use for anyone integrating our SDK. 